### PR TITLE
Fix UpdateCase comparison and cleanup services

### DIFF
--- a/src/main/java/com/dcm/modal/UpdateCase.java
+++ b/src/main/java/com/dcm/modal/UpdateCase.java
@@ -7,7 +7,7 @@ import javax.persistence.Table;
 
 @Entity
 @Table(name = "updatecase")
-public class UpdateCase implements Comparable{
+public class UpdateCase implements Comparable<UpdateCase>{
 	
 	@Id
 	@GeneratedValue
@@ -97,10 +97,12 @@ public class UpdateCase implements Comparable{
 		this.court = court;
 	}
 
-	@Override
-	public int compareTo(Object o) {
-		// TODO Auto-generated method stub
-		return 0;
-	}
+       @Override
+       public int compareTo(UpdateCase o) {
+               if (o == null) {
+                       return 1;
+               }
+               return Integer.compare(this.updateid, o.updateid);
+       }
 
 }

--- a/src/main/java/com/dcm/repository/UsersRepository.java
+++ b/src/main/java/com/dcm/repository/UsersRepository.java
@@ -20,8 +20,8 @@ public interface UsersRepository extends JpaRepository<Users, Integer>{
 	@Query(value = "select username from user where active = 1;", nativeQuery = true)
 	public String[] findUsername();
 
-	@Query(value = "select * from user where dob like ?% ;", nativeQuery = true)
-	List<Users> findBirthdays(String d);
+       @Query(value = "select * from user where dob like concat(?1, '%');", nativeQuery = true)
+       List<Users> findBirthdays(String d);
 	
 	
 	 

--- a/src/main/java/com/dcm/service/CaseService.java
+++ b/src/main/java/com/dcm/service/CaseService.java
@@ -62,9 +62,8 @@ private final CaseRepository caseRepository;
 		String d = date.format(formatters);
         System.out.println("Hearing reminder for date "+d);
 		List<Case> caseNDOH = new ArrayList<Case>();
-		caseRepository.findByNexthearing(d).forEach(caseNDOH::add);
-		d= null;	
-		return caseNDOH;
+               caseRepository.findByNexthearing(d).forEach(caseNDOH::add);
+               return caseNDOH;
 	}
 	
 	public List<Case> TodayDOH() {
@@ -72,9 +71,8 @@ private final CaseRepository caseRepository;
 		DateTimeFormatter formatters = DateTimeFormatter.ofPattern("dd-MM-yyyy");
 		String d = dash.format(formatters);
 		List<Case> caseDOH = new ArrayList<Case>();
-		caseRepository.findByNexthearing(d).forEach(caseDOH::add);
-		dash = null;
-		return caseDOH;
+               caseRepository.findByNexthearing(d).forEach(caseDOH::add);
+               return caseDOH;
 	}
 	
 	public List<Case> CategoryCount(){		

--- a/src/main/java/com/dcm/service/ReminderService.java
+++ b/src/main/java/com/dcm/service/ReminderService.java
@@ -39,9 +39,8 @@ public class ReminderService {
 		DateTimeFormatter formatters = DateTimeFormatter.ofPattern("dd-MM-yyyy");
 		String d = dash.format(formatters);
 		List<Reminder> reminder = new ArrayList<Reminder>();
-		reminderRepository.findByDate(d).forEach(reminder::add);
-		dash = null;
-		return reminder;
+               reminderRepository.findByDate(d).forEach(reminder::add);
+               return reminder;
 	}
 
 	public List<Reminder> MailReminder() {
@@ -49,9 +48,8 @@ public class ReminderService {
 		 DateTimeFormatter formatters = DateTimeFormatter.ofPattern("dd-MM-yyyy");
 		String d = date.format(formatters);
 		List<Reminder> reminder = new ArrayList<Reminder>();
-		reminderRepository.findByDate(d).forEach(reminder::add);
-		d= null;	
-		return reminder;
+               reminderRepository.findByDate(d).forEach(reminder::add);
+               return reminder;
 	}
 	
 	public List<Reminder> MailReminderwithTime() {
@@ -65,9 +63,8 @@ public class ReminderService {
 		System.out.println("Time  from mailReminderwithTime : "+time + " Date : "+d);
 		
 		List<Reminder> reminder = new ArrayList<Reminder>();
-		reminderRepository.findByDateAndTime(d, time).forEach(reminder::add);
-		d= null;	
-		return reminder;
+               reminderRepository.findByDateAndTime(d, time).forEach(reminder::add);
+               return reminder;
 	}
 
 	public List<Reminder> showByCaseno(String caseno) {

--- a/src/main/java/com/dcm/service/UpdatecaseService.java
+++ b/src/main/java/com/dcm/service/UpdatecaseService.java
@@ -38,9 +38,8 @@ private final UpdatecaseRepository updatecaseRepository;
 		DateTimeFormatter formatters = DateTimeFormatter.ofPattern("dd-MM-yyyy");
 		String d = dash.format(formatters);
 		List<UpdateCase> caseDOH = new ArrayList<UpdateCase>();
-		updatecaseRepository.findByNexthearing(d).forEach(caseDOH::add);
-		dash = null;
-		return caseDOH;
+               updatecaseRepository.findByNexthearing(d).forEach(caseDOH::add);
+               return caseDOH;
 	}
 	
 	public SortedSet<UpdateCase> HearingReminder() {
@@ -53,10 +52,9 @@ private final UpdatecaseRepository updatecaseRepository;
 		
         System.out.println("Hearing reminder for date "+d+ " & "+d2);
         
-        SortedSet<UpdateCase> caseNDOH = new TreeSet<UpdateCase>();
-		updatecaseRepository.findHearings(d2, d).forEach(caseNDOH::add);
-		d= null;	
-		return caseNDOH;
+       SortedSet<UpdateCase> caseNDOH = new TreeSet<UpdateCase>();
+               updatecaseRepository.findHearings(d2, d).forEach(caseNDOH::add);
+               return caseNDOH;
 	}
 
 }

--- a/src/main/java/com/dcm/service/UserService.java
+++ b/src/main/java/com/dcm/service/UserService.java
@@ -55,9 +55,8 @@ public class UserService{
         System.out.println("Birthday reminder for date "+d );
         
 		List<Users> birthday = new ArrayList<Users>();
-		usersRepository.findBirthdays(d).forEach(birthday::add);
-		System.out.println("Birthday wishes send for "+d );
-		d= null;	
-		return birthday;
+               usersRepository.findBirthdays(d).forEach(birthday::add);
+               System.out.println("Birthday wishes send for "+d );
+               return birthday;
 	}
 }


### PR DESCRIPTION
## Summary
- implement `Comparable<UpdateCase>` correctly
- fix birthday query in `UsersRepository`
- remove unnecessary null assignments in service classes
- return cases and reminders directly

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b029556308325b450959afa65d3b9