### PR TITLE
Fix password encoding

### DIFF
--- a/src/main/java/com/dcm/config/SecurityConfiguration.java
+++ b/src/main/java/com/dcm/config/SecurityConfiguration.java
@@ -55,25 +55,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter{
     
  
     private PasswordEncoder getPasswordEncoder() {
-        return new BCryptPasswordEncoder() {
-            @Override
-            public String encode(CharSequence charSequence) {
-            	System.out.println("Encode: "+charSequence);
-                return charSequence.toString();
-            }
-
-            @Override
-            public boolean matches(CharSequence charSequence, String s) {
-            	System.out.println("Matches: "+charSequence);
-            	System.out.println("Matches: "+s);
-//            	PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
-//            	String hashedPassword = passwordEncoder.encode(charSequence);
-//            	System.out.println("Matches: "+hashedPassword);
-            	if(charSequence.equals(s))
-                    return true;
-            	else
-            		return false;
-            }
-        };
+        // Use BCryptPasswordEncoder to store passwords securely
+        return new BCryptPasswordEncoder();
     }
 }


### PR DESCRIPTION
## Summary
- use BCryptPasswordEncoder instead of returning raw passwords

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b063174348325ac7082e9017af872